### PR TITLE
#16 : プレイヤー宣言時にそれを描画する機能の実装

### DIFF
--- a/game/mahjong.js
+++ b/game/mahjong.js
@@ -438,6 +438,14 @@ class Mahjong {
             return;
         }
 
+        // プレイヤーpがaction_typeを宣言したことを全員に通知する
+        for (var i = 0; i < 4; i++) {
+            this.players[i].sendMsg('declare', {
+                player: (p - i + 4) % 4,  // player iから見てどこか
+                action: action_type, 
+            });
+        }
+
         if (action_type == 'kan') {
             var ret = [];
             var ankans = utils.canAnkan(player.getHands());
@@ -507,9 +515,13 @@ class Mahjong {
         let action_content = {player: p, action_type: action_type, priority: priority};
         this.declare_queue.push(action_content);
         
-        // この人がmeldしたことを全員にpushする処理を入れる  FIXME #16
-        for (var i = 0; i < 4; i++)
-            this.players[i].sendMsg('declare', action_content);
+        // この人が宣言したことを全員にpushする
+        for (var i = 0; i < 4; i++) {
+            this.players[i].sendMsg('declare', {
+                player: (p - i + 4) % 4,  // player iから見てどこか
+                action: action_type, 
+            });
+        }
         
         // このプレイヤーの宣言が1番目の場合は、現在設定されているsetTimeoutを解除し、1秒後にselectDeclaredAction関数を実行する
         if (this.declare_queue.length == 1){

--- a/public/game.css
+++ b/public/game.css
@@ -246,3 +246,23 @@
   .meld-tiles{
     margin-left: 100px;
   }
+
+/* プレイヤーの宣言の表示関係 */
+.declare-window{
+  position: absolute;
+  margin: auto auto auto auto;
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.declare-msg{
+  display: none;
+  background-color: #fff;
+  font-size: xx-large;
+  position: relative;
+  padding: 3px;
+  border-radius: 25%;
+  margin: auto;
+  border: solid;
+}

--- a/public/game.html
+++ b/public/game.html
@@ -50,20 +50,32 @@
                 <div id="my-discard-area">
                     <div class="my">
                         <div id="my-discard-tiles">aaa</div>
+                        <div class="declare-window">
+                            <label id="my-declare-msg" class="declare-msg"></label>
+                        </div>
                     </div>
                 </div>
                 <div id="right-discard-area">
                     <div class="right">
                         <div id="right-discard-tiles">aaaa</div>
+                        <div class="declare-window">
+                            <label id="right-declare-msg" class="declare-msg"></label>
+                        </div>
                     </div>
                 </div>
                 <div id="opposite-discard-area">
                     <div class="opposite">
+                        <div class="declare-window">
+                            <label id="opposite-declare-msg" class="declare-msg"></label>
+                        </div>
                         <div id="opposite-discard-tiles">aaa</div>
                     </div>
                 </div>
                 <div id="left-discard-area">
                     <div class="left">
+                        <div class="declare-window">
+                            <label id="left-declare-msg" class="declare-msg"></label>
+                        </div>
                         <div id="left-discard-tiles">eee</div>
                     </div>
                 </div>

--- a/public/game.js
+++ b/public/game.js
@@ -17,6 +17,7 @@ const idx2player_map = ['my', 'right', 'opposite', 'left'];
 const gameEl = document.querySelector('#field');
 const gameStartBtn = document.querySelector('#game-start-btn');
 const actions = ['chi', 'pon', 'kan', 'ron', 'riichi', 'tsumo', 'skip'];
+const action_JPs = {'chi': "チー", 'pon': "ポン", 'kan': "カン", 'ron': "ロン", 'riichi': "リーチ", 'tsumo': "ツモ", 'skip': "スキップ"};
 const actionBtns = {};
 actions.forEach(action => {
     actionBtns[action] = document.getElementById(`${action}-btn`);
@@ -31,6 +32,7 @@ const nameEls = idx2player_map.map(p => document.getElementById(`${p}-name`));
 const handEls = idx2player_map.map(p => document.getElementById(`${p}-hand-tiles`));
 const discardEls = idx2player_map.map(p => document.getElementById(`${p}-discard-tiles`));
 const meldEls = idx2player_map.map(p => document.getElementById(`${p}-meld-tiles`));
+const declareEls = idx2player_map.map(p => document.getElementById(`${p}-declare-msg`));
 const doraEl = document.getElementById('dora-tiles');
 const wallEl = document.querySelector('wall-tiles');
 
@@ -276,6 +278,17 @@ socket.on('diff-data', (data) => {
     // 残り牌数を更新する
     tileNum.textContent = currentTilesNum;
 });
+
+
+// 立直、ポンなどの何かしらの宣言が生じた際に送られてくるイベント
+socket.on('declare', (data) => {
+    let p = data.player;         // 宣言した人
+    let action = data.action;    // 宣言の種類
+    declareEls[p].innerHTML = action_JPs[action];
+    declareEls[p].style.display = "block";
+    window.setTimeout(()=>{ declareEls[p].style.display = "none"; }, 1000);
+});
+
 
 socket.on('select-meld-cand', (data) => {
     if (data.length == 1)


### PR DESCRIPTION
- プレイヤーがポンやチーを宣言した時に、そのプレイヤーの捨牌エリア中央に1秒間その宣言を表示するようにした
![image](https://github.com/senskids/CustomMahjong/assets/39123031/8c479ff7-30af-4de5-9aca-10c134bf42cd)
