### PR TITLE
#24: 立直後の暗槓できるかどうか判定の実装

### DIFF
--- a/game/player.js
+++ b/game/player.js
@@ -114,9 +114,10 @@ class Player{
         // リーチ可能かチェック
         if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0) this.enable_actions.riichi = true;
         // 暗槓できるかチェック
-        if (utils.canAnkan(this.hands).length > 0) this.enable_actions.kan = true;
+        if (!this.is_riichi) { if (utils.canAnkan(this.hands).length > 0) this.enable_actions.kan = true; }
+        else { if (utils.canAnkanInRiichi(this.hands, this.melds, tile).length > 0) this.enable_actions.kan = true; }
         // 加槓できるかチェック
-        if (utils.canKakan(this.hands, this.melds).length > 0) this.enable_actions.kan = true;
+        if (utils.canKakan(this.hands, this.melds).length > 0 && !this.is_riichi) this.enable_actions.kan = true;
     }
 
 


### PR DESCRIPTION
### やったこと
- 立直後に暗槓できるかどうか判定する機能を付けた
- 具体的には、立直した時の待ち牌と暗槓した時の待ち牌とを比較し、同一である場合は暗槓できると判定した
- game/utils.js canAnkanInRiichi