### PR TITLE
#31: 喰い変え禁止機能の実装

### DIFF
--- a/game/player.js
+++ b/game/player.js
@@ -106,6 +106,10 @@ class Player{
         this.hands.splice(idx, 1);
         this.sortHands();
         this.discards.push(tile);
+
+        // 一時的な禁止捨牌を解除する
+        if (!this.is_riichi && this.forbidden_discards.length > 0) this.forbidden_discards = [];
+
         return true;
     }    
     
@@ -230,6 +234,11 @@ class Player{
         };
         this.is_menzen = false;
         this.melds.push(meld_info);
+
+        // 喰い変えを防止する
+        let forbidden_cands = utils.getForbiddenTilesForMeld(hand_tiles, discard_tile, meld_type);
+        this.forbidden_discards = this.hands.filter(e => forbidden_cands.includes(e));
+
         return meld_info; 
     }
 

--- a/game/utils.js
+++ b/game/utils.js
@@ -280,6 +280,33 @@ exports.getWinningTiles = function(myhands, mymelds, tsumo){
 
 
 /**
+ * 鳴いた際に捨ててはいけない牌のリストを取得する
+ * @param {Array} from_hands    手出し牌のリスト
+ * @param {Array} from_discard  捨て牌
+ * @param {String} meld_type    鳴きの種類（'pon', 'chi', 'kan'）のいずれか
+ * @returns {Array}  捨ててはいけない牌のリスト（タイルID表現）
+ */
+exports.getForbiddenTilesForMeld = function(from_hands, from_discard, meld_type){
+    if (meld_type == 'kan') return [];  // 1種につき4枚しかないので、喰い変えは発生しない
+    if (meld_type == 'pon') return [...Array(4)].map((_,i) => parseInt(from_discard / 4) * 4 + i);
+    if (from_hands.length != 2) console.log("[ERROR, utils.js, getForbiddenTilesForMeld] something wrong");
+    if (from_hands[0] > from_hands[1]) console.log("[ERROR, utils.js, getForbiddenTilesForMeld] something wrong");
+    let cands = [from_hands[0], from_hands[1], from_discard];
+    const tiles = cands.map((v,_) => (id2tile[v][1] == "0")? 5: parseInt(id2tile[v][1]));
+    if (tiles[1] - tiles[0] == 1){  
+        if ((tiles[2] - tiles[1] == 1) && tiles[0] != 1) cands.push(from_hands[0] - 4);  // [5, 6, 7] => [5, 6, 7, 4]
+        else if ((tiles[0] - tiles[2] == 1) && tiles[1] != 9) cands.push(from_hands[1] + 4);  // [5, 6, 4] => [5, 6, 4, 7]
+    }
+    let ret = [];
+    for (var i = 0; i < cands.length; i++){
+        let t = parseInt(cands[i] / 4) * 4;
+        ret = ret.concat([t, t+1, t+2, t+3]);
+    }
+    return ret;
+}
+
+
+/**
  * FIXME
  * あがり判定のための場の状況（風、ドラ、嶺上ツモ、海底ツモなど）のjsonを取得する
  * @param {JSON} field_info  FIXME　場の状況


### PR DESCRIPTION
- [m3, m4]からm5を鳴いた際に、m3, m4, m5, m2を捨てられない等の喰い変え機能を実装した
- utilsにgetForbiddenForMeld関数を実装した 