### PR TITLE
Feature/#39/last tile

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -67,3 +67,20 @@ exports.createAllRiichiTiles = function(){
     }
     return tiles;
 }
+
+
+// 海底確認用
+exports.createHaidiTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [ 0,  1,  2,  40,  44,  48,  76,  80, 84, 16, 17, 18, 52],
+        [72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84],
+        [36, 37, 38, 64, 65, 104, 100, 96, 88, 84, 80, 53, 54],
+        [71, 70, 69, 31, 30, 29, 27, 26, 25, 23, 61, 62, 63]
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}

--- a/game/mahjong.js
+++ b/game/mahjong.js
@@ -905,19 +905,19 @@ class Mahjong {
 
 
     /**
-     * FIXME 
-     * @returns 
+     * Mahjongライブラリのあがり計算に必要なフィールド情報を持ったjsonを返す関数
+     * @returns {JSON}
      */
     getFieldInfo = function(){
         return {
-            rule:           null, 
-            zhuangfeng:     this.field_count,      // 場風
-            menfeng:        this.round_count,      // 自風
+            rule:           null,                  // utilsで指定
+            zhuangfeng:     this.field_count,      // 場風 0 : 東
+            menfeng:        this.round_count,      // 自風 0 : 東
             baopai:         this.dora,             // ドラ表示牌の配列
             fubaopai:       null,                  // 裏ドラ表示牌の配列
             hupai: {
-                lizhi:      null,                  // 立直なし0, 立直1, ダブリー2
-                yifa:       false,                 // 一発
+                lizhi:      null,                  // playersで指定
+                yifa:       null,                  // 一発
                 qianggang:  false,                 // 槍槓
                 lingshang:  false,                 // 嶺上
                 haidi:      0,                     // 0: ハイテイなし、1: ハイテイツモ、2: ハイテイロン  FIXME
@@ -927,7 +927,8 @@ class Mahjong {
                 changbang:  this.honba_count,      // 積み棒の本数
                 lizhibang:  0                      // 立直棒の本数   // FIXME
             },
-            kan_num:        this.kans.length       // フィールドのカンの数
+            kan_num:        this.kans.length,      // フィールドのカンの数
+            tile_num:       this.tiles.length,     // 山牌の数
         }
     }
 

--- a/game/player.js
+++ b/game/player.js
@@ -156,12 +156,12 @@ class Player{
         // ツモあがり可能かチェック
         if (utils.canTsumo(this.hands, this.melds, tile, field_info)) this.enable_actions.tsumo = true;
         // リーチ可能かチェック
-        if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0) this.enable_actions.riichi = true;
+        if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0 && field_info["tile_num"] >= 4) this.enable_actions.riichi = true;
         // 暗槓できるかチェック
-        if (!this.is_riichi) { if (utils.canAnkan(this.hands).length > 0 && field_info["kan_num"] < 4) this.enable_actions.kan = true; }
-        else { if (utils.canAnkanInRiichi(this.hands, this.melds, tile).length > 0 && field_info["kan_num"] < 4) this.enable_actions.kan = true; }
+        if (!this.is_riichi) { if (utils.canAnkan(this.hands).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true; }
+        else { if (utils.canAnkanInRiichi(this.hands, this.melds, tile).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true; }
         // 加槓できるかチェック
-        if (utils.canKakan(this.hands, this.melds).length > 0 && !this.is_riichi && field_info["kan_num"] < 4) this.enable_actions.kan = true;
+        if (utils.canKakan(this.hands, this.melds).length > 0 && !this.is_riichi && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true;
         // 九種九牌できるかチェック
         if (this.is_first_turn && utils.canNineDiffTerminalTiles(this.hands)) this.enable_actions.drawn = true;
     }
@@ -183,11 +183,11 @@ class Player{
             return;
         }
         // 上家が捨てた場合のみ、チー出来るか判定
-        if (seat_relation == 3) if (utils.canChi(this.hands, tile).length > 0 && !this.is_riichi) this.enable_actions.chi = true;
+        if (seat_relation == 3) if (utils.canChi(this.hands, tile).length > 0 && !this.is_riichi && field_info["tile_num"] >= 1) this.enable_actions.chi = true;
         // ポン出来るか判定
-        if (utils.canPon(this.hands, tile).length > 0 && !this.is_riichi) this.enable_actions.pon = true;
+        if (utils.canPon(this.hands, tile).length > 0 && !this.is_riichi && field_info["tile_num"] >= 1) this.enable_actions.pon = true;
         // カン出来るか判定
-        if (utils.canKan(this.hands, tile).length > 0 && !this.is_riichi && field_info["kan_num"] < 4) this.enable_actions.kan = true;
+        if (utils.canKan(this.hands, tile).length > 0 && !this.is_riichi && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true;
         // ロン出来るか判定
         if (!this.is_furiten && !this.is_temporary_furiten && utils.canRon(this.hands, this.melds, tile, seat_relation, field_info)) this.enable_actions.ron = true;
         // 何かアクションを起こせるなら、スキップも押せるようにする  FIXME
@@ -256,9 +256,9 @@ class Player{
         // リーチ可能かチェック
         if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0) this.enable_actions.riichi = true;
         // 暗槓できるかチェック
-        if (utils.canAnkan(this.hands).length > 0 && field_info["kan_num"] < 4) this.enable_actions.kan = true;
+        if (utils.canAnkan(this.hands).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true;
         // 加槓できるかチェック
-        if (utils.canKakan(this.hands, this.melds).length > 0 && field_info["kan_num"] < 4) this.enable_actions.kan = true;
+        if (utils.canKakan(this.hands, this.melds).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true;
     }
 
 

--- a/game/player.js
+++ b/game/player.js
@@ -147,6 +147,9 @@ class Player{
      * @param {Array} tile      ツモした牌（タイルID表現）
      */
     checkEnableActionsForDrawTile(seat_id, tile, field_info = null){
+        // 海底ツモか確認する（嶺上ツモは別関数で処理するので、嶺上ツモで山牌が0になっても下の処理は呼ばれない（海底はつかない））
+        if (field_info.tile_num == 0) field_info.hupai.haidi = 1;
+        
         // 何もできないで初期化
         this.resetEnableActions();
         // 自分のツモじゃなかったらreturn
@@ -173,6 +176,9 @@ class Player{
      * @param {Array} tile      捨牌（タイルID表現）
      */
     checkEnableActionsForDiscardTile(seat_id, tile, field_info = null){
+        // 河底捨牌か確認する（暗槓の捨牌などでもこの関数は呼ばれる）
+        if (field_info.tile_num == 0) field_info.hupai.haidi = 2;
+
         const seat_relation = this.getSeatRelationFromSeatId(seat_id);  // 0: 自分、1: 下家、2: 対面、3: 上家
         // 初期状態として何もしてはいけないをセット
         this.resetEnableActions();
@@ -244,6 +250,9 @@ class Player{
      * @param {String} kan_type   槓の種類（'kan', 'ankan', 'kakan'）
      */
     checkEnableActionsForDrawReplacementTile(seat_id, tile, kan_type, field_info = null){
+        // 嶺上ツモであることを明記（山牌が0でも海底はつかない）
+        field_info.hupai.lingshang = true;
+
         // 何もできないで初期化
         this.resetEnableActions();
         // 自分のツモじゃなかったらreturn

--- a/game/utils.js
+++ b/game/utils.js
@@ -335,16 +335,16 @@ getObj = function(field_info){
         baopai:         field_info.baopai.map(e=>id2tile[e]),        // ドラ表示牌の配列
         fubaopai:       (field_info.fugaopai != null)? field_info.fugaopai.map(e=>id2tile[e]): null,   // 裏ドラ表示牌の配列
         hupai: {
-            lizhi:      field_info.lizhi,        // 立直なし0, 立直1, ダブリー2
-            yifa:       field_info.yifa,         // 一発
-            qianggang:  field_info.qianggang,    // 槍槓
-            lingshang:  field_info.lingshang,    // 嶺上
-            haidi:      field_info.haidi,    // 0: ハイテイなし、1: ハイテイツモ、2: ハイテイロン  FIXME
-            tianhu:     field_info.tianhu,   // 0: 天和/地和なし、1: 天和、2: 地和   FIXME
+            lizhi:      field_info.hupai.lizhi,        // 立直なし0, 立直1, ダブリー2
+            yifa:       field_info.hupai.yifa,         // 一発
+            qianggang:  field_info.hupai.qianggang,    // 槍槓
+            lingshang:  field_info.hupai.lingshang,    // 嶺上
+            haidi:      field_info.hupai.haidi,        // 0: ハイテイなし、1: ハイテイツモ、2: ハイテイロン  FIXME
+            tianhu:     field_info.hupai.tianhu,       // 0: 天和/地和なし、1: 天和、2: 地和   FIXME
         },
         jicun: {
-            changbang:  field_info.changbang,    // 積み棒の本数
-            lizhibang:  field_info.lizhibang,    // 立直棒の本数   // FIXME
+            changbang:  field_info.jicun.changbang,    // 積み棒の本数
+            lizhibang:  field_info.jicun.lizhibang,    // 立直棒の本数   // FIXME
         }
     }
 }


### PR DESCRIPTION
### やったこと
- 海底牌ツモあがりに海底撈月役をつける
- 海底牌ツモ後の捨て牌ロンで河底撈魚役をつける
- 海底牌ツモ時に暗槓、加槓できないようにする
- 連続暗槓などで山牌が0枚になった際は暗槓、加槓できないようにする
- 海底牌ツモ後の捨て牌に対して、ポン、チー、カン（大明槓）できないようにする
- 山牌が4枚以上ある（次の自分のツモがある）場合にしか立直できないようにする
- 山牌が1枚の状態で自分が槓した際に、嶺上ツモすることで山牌が0枚になるが、それでツモあがりする際には、海底撈月は付与されないようにする（嶺上開花は付与される）
- 山牌が1枚の状態で自分が槓した際に、嶺上ツモすることで山牌が0枚になるが、それであがれず牌を捨てる際は、それは河底牌とし、河底撈魚役をつけるようにする