### PR TITLE
#42:特殊役の実装

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -84,3 +84,55 @@ exports.createHaidiTiles = function(){
     }
     return tiles;
 }
+
+
+// 人和確認用
+exports.createRenheTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 132], 
+        [4, 8, 16, 17, 18, 24, 28, 32, 36, 40, 44, 76, 77],
+        [1, 16, 17, 18, 24, 25, 26, 32, 33, 34, 40, 41, 42],
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 128], 
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}
+
+
+// 嶺上開花確認用
+exports.createLingshangTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [40, 41, 42, 43, 4, 8, 12, 108, 109, 110, 133, 132, 60], 
+        [124, 125, 16, 17, 18, 24, 28, 32, 36, 40, 44, 76, 77],
+        [1, 16, 17, 18, 24, 25, 26, 32, 33, 34, 40, 41, 42],
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 128], 
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}
+
+
+// 流し満貫確認用
+exports.createDrawnManganTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [0, 1, 2, 32, 33, 34, 36, 37, 38, 68, 69, 70, 72], 
+        [124, 125, 16, 17, 18, 24, 28, 32, 36, 40, 44, 76, 77],
+        [1, 16, 17, 18, 24, 25, 26, 32, 33, 34, 40, 41, 42],
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 128], 
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}
+

--- a/public/game.js
+++ b/public/game.js
@@ -341,6 +341,11 @@ socket.on('cannot-discard-tile', (tile_id) => {
 });
 
 
+socket.on('hule', (hule) => {
+    console.log(hule);
+});
+
+
 socket.on('game-status', (data) => {
     data.names.forEach((e, i)=>{
         nameEls[i].innerHTML = e;


### PR DESCRIPTION
### やったこと
- 役に場風をつける
- 役に自風をつける
- 役に一発をつける
- 役にダブル立直をつける
- 役に嶺上開花をつける
- 役に天和をつける
- 暗槓、大明槓、加槓、ポン、チー成立時には一発、天和などがつかないようにする
- 流し満貫の実装
- 人和の実装

- あがり時にその情報をクライアントにhuleイベントで通知