### PR TITLE
#56:点数計算と点数表示の実装

### DIFF
--- a/game/player.js
+++ b/game/player.js
@@ -172,6 +172,7 @@ class Player{
         // field_infoに自身の情報を付与する（嶺上ツモは別関数で処理するので、嶺上ツモで山牌が0になっても海底はつかない）
         field_info.menfeng = this.cmenfeng;
         if (this.is_riichi) field_info.hupai.lizhi = (this.is_double_riichi)? 2: 1;
+        else field_info.fubaopai = [];
         if (this.is_oneshot) field_info.hupai.yifa = true;  // 一発
         if (this.is_first_turn) field_info.hupai.tianhu = (this.cmenfeng == 0)? 1: 2;
         if (field_info.tile_num == 0) field_info.hupai.haidi = 1;
@@ -182,7 +183,7 @@ class Player{
         this.hule_info = utils.canTsumo(this.hands, this.melds, tile, field_info);
         if (this.hule_info != undefined && this.hule_info.defen != 0) this.enable_actions.tsumo = true;
         // リーチ可能かチェック
-        if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0 && field_info["tile_num"] >= 4) this.enable_actions.riichi = true;
+        if (this.is_menzen && !this.is_riichi && utils.canRiichi(this.hands, this.melds).length > 0 && field_info["tile_num"] >= 4 && this.point >= 1000) this.enable_actions.riichi = true;
         // 暗槓できるかチェック
         if (!this.is_riichi) { if (utils.canAnkan(this.hands).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true; }
         else { if (utils.canAnkanInRiichi(this.hands, this.melds, tile).length > 0 && field_info["kan_num"] < 4 && field_info["tile_num"] >= 1) this.enable_actions.kan = true; }
@@ -211,6 +212,7 @@ class Player{
         // field_infoに自身の情報を付与する
         field_info.menfeng = this.cmenfeng;
         if (this.is_riichi) field_info.hupai.lizhi = (this.is_double_riichi)? 2 : 1;
+        else field_info.fubaopai = [];
         if (this.is_oneshot) field_info.hupai.yifa = true;         // 一発
         if (this.is_first_turn) field_info.hupai.tianhu = 3;       // 人和
         if (field_info.tile_num == 0) field_info.hupai.haidi = 2;  // 暗槓の捨牌などでも河底捨牌
@@ -274,6 +276,7 @@ class Player{
         field_info.menfeng = this.cmenfeng;
         field_info.hupai.qianggang = true;  // 槍槓
         if (this.is_riichi) field_info.hupai.lizhi = (this.is_double_riichi)? 2 : 1;
+        else field_info.fubaopai = [];
         if (this.is_oneshot) field_info.hupai.yifa = true;  // 一発
         if (this.is_first_turn) field_info.hupai.tianhu = 3;
 
@@ -449,7 +452,7 @@ class Player{
      * 立直を実行する（内部を立直状態にする）
      * @param {Number} hand_tile   手牌から抜き出す牌（タイルID表現）
      */
-    performRiichi(hand_tile){
+    declareRiichi(hand_tile){
         this.is_riichi = true;
         this.is_oneshot = true;
         if (this.is_first_turn) this.is_double_riichi = true;
@@ -499,7 +502,7 @@ class Player{
         return this.user_id;
     }
     getUserName(){
-        return (this.is_active)? this.user_name+" "+this.getOwnWind(this.seat): this.user_name + "(cpu)"+" "+this.getOwnWind(this.seat);
+        return (this.is_active)? this.user_name: this.user_name + "(cpu)";
     }
     getActive(){
         return this.is_active;
@@ -525,22 +528,8 @@ class Player{
     getEnableActions(){
         return this.enable_actions;
     }
-    getOwnWind(user_wind){
-        switch(this.seat){
-            case 0:
-                user_wind = "<a class=\"player_wind\">東</a>";
-                break;
-            case 1:
-                user_wind = "<a class=\"player_wind\">南</a>";
-                break;
-            case 2:
-                user_wind = "<a class=\"player_wind\">西</a>";
-                break;
-            case 3:
-                user_wind = "<a class=\"player_wind\">北</a>";
-                break;
-        }
-        return user_wind;
+    getOwnWind(){
+        return ["東", "南", "西", "北"][this.seat];
     }
     getHuleInfo(){
         return this.hule_info;
@@ -550,6 +539,15 @@ class Player{
     }
     getTenpai(){
         return this.is_tenpai;
+    }
+    /**
+     * 点棒をやりとりする
+     * @param {Number} diff_point  点棒の差分（+：もらう、-：払う）
+     * @return {Boolean}  持ち点が0点以上かどうか（true：0点以上、false：マイナス）
+     */
+    setDiffPoint(diff_point){
+        this.point += diff_point;
+        return this.point >= 0;
     }
 
     /////////////////////////////////////////////

--- a/game/utils.js
+++ b/game/utils.js
@@ -253,12 +253,12 @@ exports.canTsumo = function(hands, melds, tsumo, field_info){
  * @param {Array} myhands         プレイヤーの手牌、ツモ牌も含む（タイルID表現） 
  * @param {Array} mymelds         プレイヤーの鳴き牌（鳴き牌表現） 
  * @param {Number} discard        捨牌のタイルID
- * @param {Number} seat_relation  プレイヤーと捨牌プレイヤーの座席関係（0～3）
+ * @param {Number} seat_relation  プレイヤーと捨牌プレイヤーの座席関係（0:自分、1:下家、2:対面、3:上家）
  * @param {JSON} field_info       FIXME
  * @returns {*}      Majiangライブラリのhule情報（json）
  */
 exports.canRon = function(myhands, mymelds, discard, seat_relation, field_info){
-    const d_tile = id2tile[discard] + ["","-","=","+"][seat_relation];
+    const d_tile = id2tile[discard] + ["","+","=","-"][seat_relation];  // +:下家、=:対面、-:上家
     const obj = getObj(field_info);
     let ret = Majiang.Util.hule(convert2Majiang(myhands, mymelds, null), d_tile, obj);
     // 人和の反映（Majiangライブラリに実装されていない）

--- a/public/game.css
+++ b/public/game.css
@@ -45,7 +45,7 @@
     /* margin: auto; */
     background-color: rgba(0, 128, 0, 0.664);
   }
-  .player-name{
+  .player-info-area{
     background-color: rgb(224, 224, 224);
     display: inline-block;
     border-radius: 10%;
@@ -55,8 +55,20 @@
     margin: 1%;
     padding: 0.5rem;
   }
-  .player_wind{
+  .player-info{
+    display: flex;
+  }
+  .player-name{
+    margin: 0 5px 0 5px;
+    color: black;
+  }
+  .player-wind{
+    margin: 0 5px 0 5px;
     color: blue;
+  }
+  .player-point{
+    margin: 0 5px 0 5px;
+    color: black;
   }
 
   #my-main-area {

--- a/public/game.html
+++ b/public/game.html
@@ -20,7 +20,13 @@
             <div id="game-board">
                 <div id="my-main-area">
                     <div class="my">
-                        <div id="my-name" class="player-name">あああ</div>
+                        <div class="player-info-area">
+                            <div class="player-info">
+                                <div id="my-name" class="player-name">あああ</div>
+                                <div id="my-wind" class="player-wind">東</div>
+                                <div id="my-point" class="player-point">25000</div>
+                            </div>
+                        </div>
                         <div style="display:flex">
                             <div id="my-hand-tiles">あああ</div>
                             <div id="my-meld-tiles" style="padding-left: 1rem;">いいい</div>
@@ -29,7 +35,13 @@
                 </div>
                 <div id="right-main-area">
                     <div class="right">
-                        <div id="right-name" class="player-name">あああ</div>
+                        <div class="player-info-area">
+                            <div class="player-info">
+                                <div id="right-name" class="player-name">あああ</div>
+                                <div id="right-wind" class="player-wind">南</div>
+                                <div id="right-point" class="player-point">25000</div>
+                            </div>
+                        </div>
                         <div style="display:flex">
                             <div id="right-hand-tiles">aaa</div>
                             <div id="right-meld-tiles" style="padding-left: 1rem;">iii</div>
@@ -38,7 +50,13 @@
                 </div>
                 <div id="opposite-main-area">
                     <div class="opposite">
-                        <div id="opposite-name" class="player-name">あああ</div>
+                        <div class="player-info-area">
+                            <div class="player-info">
+                                <div id="opposite-name" class="player-name">あああ</div>
+                                <div id="opposite-wind" class="player-wind">西</div>
+                                <div id="opposite-point" class="player-point">25000</div>
+                            </div>
+                        </div>
                         <div style="display:flex">
                             <div id="opposite-hand-tiles">aaaa</div>
                             <div id="opposite-meld-tiles" style="padding-left: 1rem;">iii</div>
@@ -47,7 +65,13 @@
                 </div>
                 <div id="left-main-area">
                     <div class="left">
-                        <div id="left-name" class="player-name">あああ</div>
+                        <div class="player-info-area">
+                            <div class="player-info">
+                                <div id="left-name" class="player-name">あああ</div>
+                                <div id="left-wind" class="player-wind">北</div>
+                                <div id="left-point" class="player-point">25000</div>
+                            </div>
+                        </div>
                         <div style="display:flex">
                             <div id="left-hand-tiles">uuu</div>
                             <div id="left-meld-tiles" style="padding-left: 1rem;">eee</div>

--- a/public/game.js
+++ b/public/game.js
@@ -32,7 +32,9 @@ actions.forEach(action => {
     });    
 });
 
-const nameEls = idx2player_map.map(p => document.getElementById(`${p}-name`));
+// playerInfoEls[playerIdx]["name" or "point" or "wind"]
+const playerInfoEls = idx2player_map.map(p => {return {"name":document.getElementById(`${p}-name`), 
+"point":document.getElementById(`${p}-point`), "wind":document.getElementById(`${p}-wind`)}});
 const handEls = idx2player_map.map(p => document.getElementById(`${p}-hand-tiles`));
 const discardEls = idx2player_map.map(p => document.getElementById(`${p}-discard-tiles`));
 const meldEls = idx2player_map.map(p => document.getElementById(`${p}-meld-tiles`));
@@ -186,6 +188,9 @@ socket.on('data', (data) => {
 
     // ドラ
     doraTiles = data.doraTiles.value;
+
+    // 点数
+    for (var i = 0; i < 4; i++) playerInfoEls[i]["point"] = 25000;
 
     // 牌を描画する
     for(var i = 0; i < 4; i++){
@@ -408,9 +413,18 @@ socket.on('one-game-end', (results) => {
 });
 
 
+socket.on('point', (points) => {
+    for (var i = 0; i < points.length; i++){
+        playerInfoEls[i]["point"].innerHTML = points[i];
+    }
+});
+
+
 socket.on('game-status', (data) => {
+    // data.seat : 起家は誰か（fixme : 誰が本局の親（東）かに変える）
     data.names.forEach((e, i)=>{
-        nameEls[i].innerHTML = e;
+        playerInfoEls[i]["name"].innerHTML = e;
+        playerInfoEls[i]["wind"].innerHTML = ["東", "南", "西", "北"][(i + data.seat + 4) % 4];
     });
 });
 

--- a/server.js
+++ b/server.js
@@ -101,8 +101,7 @@ io.on('connection', (socket) => {
 
     // プレイヤーが立直を宣言したときの処理
     socket.on('declare-riichi', (discardTile) => {
-        console.log("[declare-riichi]");
-        game.performRiichi(socket.id, discardTile);
+        game.declareRiichi(socket.id, discardTile);
     });
     
     // プレイヤーがツモあがりを宣言したときの処理


### PR DESCRIPTION
### やったこと
- 立直時に供託に1000点を出すようにする（1000点未満の場合は立直宣言できない）
- あがり時の点棒やりとりを実装する
- 点数変動があった際に、クライアントにそれを通知する
- ゲーム画面に点数を表示する（写真）

### 細かい修正点
- これまでのperformRiichi関数（立直を宣言し、捨て牌を切る）の名前をdeclareRiichiに変更
- 新しくperformRiichi関数（立直が確定し、1000点棒を供託に出す）を実装
- one-game-endイベントからdiff_score情報を削除し、pointイベントで点数を送るように変更

![image](https://github.com/senskids/CustomMahjong/assets/39123031/0b02bc99-1dca-4e5d-a510-baf7698412e6)
