### PR TITLE
#57:大明槓嶺上開花責任払い、大三元等確定者責任払いの実装

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -136,3 +136,37 @@ exports.createDrawnManganTiles = function(){
     return tiles;
 }
 
+
+// 嶺上開花大明槓責任払い確認用
+exports.createLingshangBaojiaTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [0 ,  1,  2, 4, 8, 12, 108, 109, 110, 72, 76, 80, 60], 
+        [3, 125, 16, 17, 18, 24, 28, 32, 36, 40, 44, 76, 77],
+        [1, 16, 17, 18, 24, 25, 26, 32, 33, 34, 40, 41, 42],
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 128], 
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}
+
+
+// 大三元大明槓責任払い確認用
+exports.createBaojiaTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [124, 125, 128, 129, 135, 134, 0, 1, 2, 4, 5, 6, 108], 
+        [126, 130, 12, 17, 18, 24, 28, 32, 36, 40, 44, 76, 77],
+        [1, 16, 17, 18, 24, 25, 26, 32, 33, 34, 40, 41, 42],
+        [0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14, 128], 
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}
+

--- a/game/player.js
+++ b/game/player.js
@@ -637,7 +637,7 @@ class Player{
         this.game_manager.notTurnPlayerDeclareAction(this.seat, "skip");
     }
     sayDiscard(){
-        this.game_manager.discardTile(this.seat, this.hands[this.hands.length - 1]);
+        this.game_manager.discardTile(this.seat, this.hands[0]);
     }
     sayConfirm(){
         this.game_manager.doConfirm(this.seat);

--- a/game/utils.js
+++ b/game/utils.js
@@ -61,7 +61,7 @@ function convert2Majiang(hands = [], melds = [], tsumo = null) {
         let hs = info.hands.map((e, i) => (id2tile[e][1] != "0")? [parseInt(id2tile[e][1]) + 0.1 * i, id2tile[e][1]]: [4.5 + 0.1 * i, "0"]);
         if (info.from_who != null){  // 暗槓以外の場合
             let d = id2tile[info.discard];
-            let ap = ['', '-', '=', '+'][info.from_who];
+            let ap = ['', '+', '=', '-'][info.from_who];
             hs = hs.concat([(d[1] != "0")? [parseInt(d[1]) + 0.25, d[1] + ap]: [4.75, `0${ap}`]]);
         }
         hs.sort((a, b) => a[0] - b[0]);

--- a/public/game.js
+++ b/public/game.js
@@ -189,9 +189,6 @@ socket.on('data', (data) => {
     // ドラ
     doraTiles = data.doraTiles.value;
 
-    // 点数
-    for (var i = 0; i < 4; i++) playerInfoEls[i]["point"] = 25000;
-
     // 牌を描画する
     for(var i = 0; i < 4; i++){
         renderTiles(handEls[i], handTiles[i], (i == 0)? "100px":"30px", (i == 0)? true: false);


### PR DESCRIPTION
### やったこと
- 大明槓からの嶺上開花の場合に、槓させた人の1人払いにする（加槓後の嶺上開花はなし）
- 大三元、大四喜、小四喜、四槓子の最後の面子を鳴かせた（役を確定させた）人は、ツモ上がりされた場合は1人払い、ロン上がりされた場合はロンされた人と半々払いにする（複合役満の場合は、確定させた役だけの責任を持つようにする）