### PR TITLE
#53:牌切り時の描画改善＆renderTiles周りのrefactoring

### DIFF
--- a/public/game.css
+++ b/public/game.css
@@ -310,18 +310,6 @@
     padding: 2rem 0rem 6rem 0rem;
   }
 
-  .last-my-tile{
-    margin-left: 50px;
-  }
-
-  .last-other-tile{
-    margin-left: 20px;
-  }
-
-  .meld-tiles{
-    margin-left: 100px;
-  }
-
 /* プレイヤーの宣言の表示関係 */
 .declare-window{
   position: absolute;


### PR DESCRIPTION
### やったこと
- 牌を切る際に、切った場所を短時間可視化するようにした
- グローバル変数、ローカル変数、関数引数の見直し（is_Draw, is_Render, is_currentなどを、グローバル変数lastCommands（各プレイヤーからの直前のコマンドを格納する）に集約した）
![discard_movie](https://github.com/senskids/CustomMahjong/assets/39123031/e4658402-c050-4578-a40a-665bb76b4c7f)
