### PR TITLE
#97:持ち時間を追加した（サーバー側との遅延を考慮していない）

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -170,3 +170,19 @@ exports.createBaojiaTiles = function(){
     return tiles;
 }
 
+
+// チーするときの候補が2つ以上あるときの確認用
+exports.createTwoCandidateTiles = function(){
+    let tiles = [...Array(136)].map((_, i) => i);
+    let inits = [
+        [0, 1, 2, 4, 5, 6, 12, 13, 14, 16, 17, 18, 9],
+        [0, 1, 2, 4, 5, 6, 12, 13, 14, 16, 17, 18, 9],
+        [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9],
+        [9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9],
+    ];
+    for (var p = 0; p < 4; p++){
+        for (var i = 0; i < 13; i++)
+            tiles[p * 13 + i] = inits[p][i];
+    }
+    return tiles;
+}

--- a/game/player.js
+++ b/game/player.js
@@ -1,3 +1,4 @@
+const Mahjong = require('./mahjong');
 const utils = require('./utils');
 
 class Player{
@@ -56,7 +57,9 @@ class Player{
         /** 今上がった際の点数 FIXME */
         this.hule_info = undefined;
         /** 持ち時間  FIXME 実装していない */
-        this.allotted_time = 10;
+        this.allotted_time = null;
+        /** 時間管理用の変数 */
+        this.time_start = null;
         /** プレイヤーが現在可能なアクションの辞書 */
         this.enable_actions = {
             discard: false, 
@@ -565,6 +568,17 @@ class Player{
     }
     getTenpai(){
         return this.is_tenpai;
+    }
+    resetStartTime(){
+        this.time_start = Date.now();
+    }
+    updateAllottedTime(){
+        // Data.now()はミリ秒単位
+        console.log("updateAllottedTime", (Date.now() - this.time_start)/1000.0);
+        if( (Date.now() - this.time_start)/1000.0 - this.game_manager.additional_allotted_time > 0) {
+            this.allotted_time -= Math.floor((Date.now() - this.time_start)/1000.0) - this.game_manager.additional_allotted_time;
+        }
+        this.time_start = null;
     }
     /**
      * 点棒をやりとりする

--- a/public/game.css
+++ b/public/game.css
@@ -182,6 +182,28 @@
     /* color: rgb(252, 252, 19); */
   }
 
+  .player-info-container{
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .my-remain-time{
+    display: inline-block;
+    padding: 0.5rem;
+    margin-left: auto;
+    margin-right: 20%;
+  }
+  
+  #addition-time{
+    font-size: 36px;
+    display: inline-block;
+  }
+  
+  #remain-time{
+    font-size: 36px;
+    display: inline-block;
+  }
+
   .meld-area{
     margin-left: auto;
     margin-right: 5%;

--- a/public/game.html
+++ b/public/game.html
@@ -21,13 +21,19 @@
                 <div class="my main-area">
                     <div>
                         <div>
-                            <div class="player-info-area">
-                                <div class="player-info">
-                                    <div class="player-status">
-                                        <div id="my-wind" class="player-wind">東</div>
-                                        <div id="my-point" class="player-point">25000</div>
+                            <div class="player-info-container">
+                                <div class="player-info-area">
+                                    <div class="player-info">
+                                        <div class="player-status">
+                                            <div id="my-wind" class="player-wind">東</div>
+                                            <div id="my-point" class="player-point">25000</div>
+                                        </div>
+                                        <div id="my-name" class="player-name"></div>
                                     </div>
-                                    <div id="my-name" class="player-name"></div>
+                                </div>
+                                <div class="my-remain-time">
+                                    <div id="addition-time"></div>
+                                    <div id="remain-time"></div>
                                 </div>
                             </div>
                             <div class="player-tiles-container">


### PR DESCRIPTION
右の方に自分の持ち時間が表示されるようにした。
何かの操作を始めるときに時間が５秒与えられ、５秒を超えると自分の持ち時間から減っていく。
”５＋持ち時間”という形で表示される。最初に与えられる持ち時間は１０秒。
プレイヤーの持ち時間はmahjong.jsのdefault_allotted_timeで、操作を始めるときに与えられる時間はmahjong.jsのadditional_allotted_timeで変更できる。
サーバー側で時間を管理している。
サーバー側からクライアント側にデータを送るときに遅延が生じることが考えられるが、その遅延を考慮した実装はできていない。